### PR TITLE
[Bug] Fix alignment calculation in allocate_layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ impl<const N: usize, O: OligarchyCollection, B: BuddyCollection> BuddyAllocator<
         }
 
         if let Some(size) = NonZeroUsize::new(layout.size()) {
-            self.allocate(layout.align().trailing_zeros() as _, size)
+            self.allocate(layout.align() as _, size)
         } else {
             Ok(allocated(self, 0))
         }


### PR DESCRIPTION
allocate() expects align_order to be a power of two, instead of the number of trailing zeros