### PR TITLE
fix: handle null buddy pointer in LinkedListBuddy and AvlBuddy

### DIFF
--- a/src/avl.rs
+++ b/src/avl.rs
@@ -285,7 +285,9 @@ impl Tree {
             // if this node is not empty
             Some(mut root_ptr) => {
                 let root = unsafe { root_ptr.as_mut() };
-                let buddy = order.idx_to_ptr::<Node>(idx ^ 1).expect("buddy address is null");
+                let buddy = order
+                    .idx_to_ptr::<Node>(idx ^ 1)
+                    .expect("buddy address is null");
                 use core::cmp::Ordering::*;
                 // use core::mem::replace;
 

--- a/src/avl.rs
+++ b/src/avl.rs
@@ -77,7 +77,6 @@ use core::{fmt, ptr::NonNull};
 /// 基于平衡二叉查找树的侵入式伙伴行。
 pub struct AvlBuddy {
     tree: Tree,
-    base: usize,
     order: Order,
 }
 
@@ -89,13 +88,11 @@ impl BuddyLine for AvlBuddy {
 
     const EMPTY: Self = Self {
         tree: Tree(None),
-        base: 0,
         order: Order::new(0),
     };
 
     #[inline]
-    fn init(&mut self, order: usize, base: usize) {
-        self.base = base;
+    fn init(&mut self, order: usize, _base: usize) {
         self.order = Order::new(order);
     }
 
@@ -132,6 +129,11 @@ impl BuddyCollection for AvlBuddy {
     /// insert node into avl_buddy
     fn put(&mut self, idx: usize) -> Option<usize> {
         // 需要额外考虑一个事情，就是在进行分配的时候，最小分配单元必须大于Node，因为这个Node实际上是存放在分配的空间中的，因此需要加入判定以确保空间不会出现重叠的情况
+        // buddy序号为 0 时地址为空指针，跳过合并。
+        if idx ^ 1 == 0 {
+            self.tree.insert_no_merge(idx, &self.order);
+            return None;
+        }
         if self.tree.insert(idx, &self.order) {
             None
         } else {
@@ -278,12 +280,12 @@ impl Tree {
         // 这个地方我认为目前的速度瓶颈主要出现在大量使用递归所带来的影响，但是考虑到本lab主要完成的是分配器，因此可能没有办法实现动态的内存分配，进而使用栈或者队列来实现对应操作
 
         // 版本二：在进行插入的时候直接完成对应伙伴节点的删除工作
-        let ptr: NonNull<Node> = unsafe { order.idx_to_ptr(idx) };
+        let ptr: NonNull<Node> = order.idx_to_ptr(idx).expect("block address is null");
         match self.0 {
             // if this node is not empty
             Some(mut root_ptr) => {
                 let root = unsafe { root_ptr.as_mut() };
-                let buddy = unsafe { order.idx_to_ptr(idx ^ 1) };
+                let buddy = order.idx_to_ptr::<Node>(idx ^ 1).expect("buddy address is null");
                 use core::cmp::Ordering::*;
                 // use core::mem::replace;
 
@@ -663,12 +665,39 @@ impl Tree {
             // if this node is empty => insert in this point
             None => {
                 self.0 = Some(ptr);
-                *unsafe { order.idx_to_ptr(idx).as_mut() } = Node {
+                *unsafe { order.idx_to_ptr(idx).unwrap().as_mut() } = Node {
                     l: Tree(None),
                     r: Tree(None),
                     h: 1,
                 };
                 true
+            }
+        }
+    }
+
+    /// 插入结点（不合并buddy）。buddy地址为空时使用。
+    fn insert_no_merge(&mut self, idx: usize, order: &Order) {
+        let ptr: NonNull<Node> = order.idx_to_ptr(idx).expect("block address is null");
+        match self.0 {
+            Some(mut root_ptr) => {
+                let root = unsafe { root_ptr.as_mut() };
+                if ptr < root_ptr {
+                    root.l.insert_no_merge(idx, order);
+                } else {
+                    root.r.insert_no_merge(idx, order);
+                }
+                root.update();
+                self.rotate();
+            }
+            None => {
+                self.0 = Some(ptr);
+                unsafe {
+                    ptr.as_ptr().write(Node {
+                        l: Tree(None),
+                        r: Tree(None),
+                        h: 1,
+                    });
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -696,7 +696,9 @@ mod tests {
         struct Buf {
             _data: [u8; 128 * 1024],
         }
-        static mut BUF: Buf = Buf { _data: [0; 128 * 1024] };
+        static mut BUF: Buf = Buf {
+            _data: [0; 128 * 1024],
+        };
 
         type A = BuddyAllocator<32, UsizeBuddy, LinkedListBuddy>;
         let mut alloc = A::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,8 +381,8 @@ impl Order {
     }
 
     #[inline]
-    unsafe fn idx_to_ptr<T>(&self, idx: usize) -> NonNull<T> {
-        unsafe { NonNull::new_unchecked((idx << self.0) as *mut _) }
+    fn idx_to_ptr<T>(&self, idx: usize) -> Option<NonNull<T>> {
+        NonNull::new((idx << self.0) as *mut _)
     }
 
     #[inline]
@@ -652,14 +652,15 @@ mod tests {
         let order = Order::new(12);
 
         // 测试 idx 到 ptr 的转换
-        // idx=0 会生成空指针，所以从 1 开始
-        let ptr = unsafe { order.idx_to_ptr::<u8>(1) };
+        // idx=0 对应空指针，返回 None
+        assert!(order.idx_to_ptr::<u8>(0).is_none());
+        let ptr = order.idx_to_ptr::<u8>(1).unwrap();
         assert_eq!(ptr.as_ptr() as usize, 4096); // 1 << 12
 
-        let ptr = unsafe { order.idx_to_ptr::<u8>(2) };
+        let ptr = order.idx_to_ptr::<u8>(2).unwrap();
         assert_eq!(ptr.as_ptr() as usize, 8192); // 2 << 12
 
-        let ptr = unsafe { order.idx_to_ptr::<u8>(3) };
+        let ptr = order.idx_to_ptr::<u8>(3).unwrap();
         assert_eq!(ptr.as_ptr() as usize, 12288); // 3 << 12
     }
 
@@ -682,9 +683,33 @@ mod tests {
         // 测试 idx -> ptr -> idx 的往返转换
         // idx=0 会生成空指针，所以从 1 开始
         for i in [1, 5, 100, 1000] {
-            let ptr = unsafe { order.idx_to_ptr::<u8>(i) };
+            let ptr = order.idx_to_ptr::<u8>(i).unwrap();
             let idx = order.ptr_to_idx(ptr);
             assert_eq!(idx, i);
         }
+    }
+
+    /// 回归测试：低地址缓冲区跨越 2 的幂次边界时，buddy序号为 0 导致空指针。
+    #[test]
+    fn test_transfer_low_address_crossing_boundary() {
+        #[repr(C, align(4096))]
+        struct Buf {
+            _data: [u8; 128 * 1024],
+        }
+        static mut BUF: Buf = Buf { _data: [0; 128 * 1024] };
+
+        type A = BuddyAllocator<32, UsizeBuddy, LinkedListBuddy>;
+        let mut alloc = A::new();
+
+        let ptr = NonNull::new((&raw mut BUF).cast::<u8>()).unwrap();
+        let len = 128 * 1024;
+
+        alloc.init(3, ptr);
+        unsafe { alloc.transfer(ptr, len) };
+
+        let size = NonZeroUsize::new(4096).unwrap();
+        let (p, s) = alloc.allocate::<u8>(0, size).unwrap();
+        assert!(s >= 4096);
+        alloc.deallocate(p, s);
     }
 }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -50,8 +50,8 @@ impl OligarchyCollection for LinkedListBuddy {
     // 向头结点处插入一个节点
     #[inline]
     fn put(&mut self, idx: usize) {
-        self.free_list
-            .insert_unordered(unsafe { self.order.idx_to_ptr(idx) });
+        let ptr = self.order.idx_to_ptr(idx).expect("block address is null");
+        self.free_list.insert_unordered(ptr);
     }
 }
 
@@ -71,8 +71,12 @@ impl BuddyCollection for LinkedListBuddy {
     // 向对应位置插入一个新的元素
     fn put(&mut self, idx: usize) -> Option<usize> {
         // 伙伴和当前结点存在链表的同一个位置。
-        let node = unsafe { self.order.idx_to_ptr(idx) };
-        let buddy = unsafe { self.order.idx_to_ptr(idx ^ 1) };
+        let node = self.order.idx_to_ptr(idx).expect("block address is null");
+        // buddy序号为 0 时地址为空指针，不可能在空闲链表中，跳过合并。
+        let Some(buddy) = self.order.idx_to_ptr(idx ^ 1) else {
+            self.free_list.insert_unordered(node);
+            return None;
+        };
         if self.free_list.insert(node, buddy) {
             None
         } else {


### PR DESCRIPTION
 ## 问题
`LinkedListBuddy::put` 和 `AvlBuddy` 的 `Tree::insert` 中，通过 `idx ^ 1` 计算 buddy 序号后调用 `idx_to_ptr`。当 `idx == 1` 时，`idx ^ 1 == 0`，而 `idx_to_ptr(0)` 通过 `NonNull::new_unchecked(0)` 生成空指针，debug 模式下触发 panic，release 模式下可能导致空指针解引用。

- 触发条件：管理的内存区域起始地址低于某个 `2^n` 边界且跨越该边界。`deallocate` 在该边界处产生 order-n 的块，序号为 1，其 buddy 序号为 0。
- 场景：RISC-V 用户程序默认链接在 `0x10000`，512 KiB 的静态堆缓冲区位于 `0x1ab70`，跨越 `0x20000` 边界。`transfer` 时在 order 17 产生 `idx=1` 的块，计算 buddy `idx_to_ptr(0)` 崩溃。

## 修复
- `Order::idx_to_ptr` 返回 `Option<NonNull<T>>`
- 对于`LinkedListBuddy::put`，buddy 为 `None` 时跳过合并，直接插入
- 对于`AvlBuddy::put`，`idx ^ 1 == 0` 时通过 `insert_no_merge` 插入
- `AvlBuddy`：移除无用的 `base` 字段（写入后从未读取？）
- 添加回归测试